### PR TITLE
fix extraneous error of rvm/rbenv `type`

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -38,9 +38,9 @@ function __git_status
 end
 
 function __ruby_version
-  if type "rvm-prompt" > /dev/null
+  if type "rvm-prompt" > /dev/null 2>&1
     set ruby_version (rvm-prompt i v g)
-  else if type "rbenv" > /dev/null
+  else if type "rbenv" > /dev/null 2>&1
     set ruby_version (rbenv version-name)
   else
     set ruby_version "system"


### PR DESCRIPTION
Hi, 

I have seen errors like the following after upgrade to latest oh-my-fish:

```
type: Could not find “rvm-prompt”
type: Could not find “rbenv”
```

I think this is the same error as https://github.com/oh-my-fish/oh-my-fish/issues/370. 
I have tried to apply the same fix and it seems working on my machine.

Thank you!
