### PR TITLE
Fix for "Unknown command: hostname" error

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -8,7 +8,7 @@ function __user_host
   else
     echo -n (set_color --bold green)
   end
-  echo -n $USER@(hostname|cut -d . -f 1) (set color normal)
+  echo -n $USER@(uname -n|cut -d . -f 1) (set color normal)
 end
 
 function __current_path


### PR DESCRIPTION
When trying out the theme, every command would display the following error:
```bash
fish: Unknown command: hostname
~/.config/fish/functions/fish_prompt.fish (line 1): 
hostname|cut -d . -f 1
^~~~~~~^
in command substitution
	called on line 11 of file ~/.config/fish/functions/fish_prompt.fish
in function '__user_host'
	called on line 54 of file ~/.config/fish/functions/fish_prompt.fish
in function 'fish_prompt'
in command substitution
~/.config/fish/functions/fish_prompt.fish (line 11): Unknown command
  echo -n $USER@(hostname|cut -d . -f 1) (set color normal)
                ^~~~~~~~~~~~~~~~~~~~~~~^
in function '__user_host'
	called on line 54 of file ~/.config/fish/functions/fish_prompt.fish
in function 'fish_prompt'
in command substitution
```

Referencing other oh-my-fish themes, it seems the preferred way of getting the hostname is with `uname -n`.